### PR TITLE
NVSHAS-9424: The redirections of goToNv functionalities are not completed yet

### DIFF
--- a/pkg/neuvector-ui-ext/components/Vulnerabilities/dialogs/components/ImpactModalNodeBrief.vue
+++ b/pkg/neuvector-ui-ext/components/Vulnerabilities/dialogs/components/ImpactModalNodeBrief.vue
@@ -1,6 +1,6 @@
 <script>
 import { EOS_LAUNCH_FILLED } from 'eos-icons-vue2';
-import { capitalize } from '../../../../utils/common';
+import { capitalize, getSSOUrl } from '../../../../utils/common';
 import dayjs from 'dayjs';
 
 export default {
@@ -17,11 +17,11 @@ export default {
         };
     },
     methods: {
-        goToHosts() {
-
+        goToNvHosts() {
+            window.open(`${getSSOUrl('#/hosts')}`, '_blank');
         },
-        goToGroup(group) {
-
+        goToNvGroup(group) {
+            window.open(`${getSSOUrl('#/group')}?group=${group}`, '_blank');
         }
     }
 }
@@ -139,8 +139,8 @@ export default {
                             {{ host.scan_summary.low }}
                         </span>
                         <a v-if="host.scan_summary?.high || host.scan_summary?.medium"
-                            @click="goToHosts()"
-                            style="display: table-cell; font-size: 11px; line-height: 15px">
+                            @click="goToNvHosts()"
+                            style="display: table-cell; font-size: 11px; line-height: 15px; cursor: pointer;">
                             <EOS_LAUNCH_FILLED size="base" color="#3D98D3"></EOS_LAUNCH_FILLED>
                         </a>
                         <label v-if="host.scan_summary?.scanned_at &&
@@ -160,8 +160,8 @@ export default {
                     <span class="ml mr-lg auto-hide host-item-key">
                         nodes
                         <a
-                            @click="goToGroup('nodes')"
-                            style="display: table-cell; font-size: 11px; line-height: 15px">
+                            @click="goToNvGroup('nodes')"
+                            style="display: table-cell; font-size: 11px; line-height: 15px; cursor: pointer;">
                             <EOS_LAUNCH_FILLED size="base" color="#3D98D3"></EOS_LAUNCH_FILLED>
                         </a>
                     </span>

--- a/pkg/neuvector-ui-ext/components/Vulnerabilities/dialogs/components/ImpactModalWorkloadBrief.vue
+++ b/pkg/neuvector-ui-ext/components/Vulnerabilities/dialogs/components/ImpactModalWorkloadBrief.vue
@@ -1,6 +1,6 @@
 <script>
 import { EOS_LAUNCH_FILLED } from 'eos-icons-vue2';
-import { shortenString } from '../../../../utils/common';
+import { shortenString, getSSOUrl } from '../../../../utils/common';
 import dayjs from 'dayjs';
 
 export default {
@@ -34,8 +34,8 @@ export default {
         }
     },
     methods: {
-        goToGroup(group) {
-
+        goToNvGroup(group) {
+            window.open(`${getSSOUrl('#/group')}?group=${group}`, '_blank');
         }
     }
 }
@@ -115,8 +115,10 @@ export default {
                                 <span v-tooltip.top="{ content: workload.service_group }" ref="ttWorkloadServiceGroup">
                                     {{ shortenString(workload.service_group, 30) }}
                                 </span>
-                                <a @click="goToGroup(workload.service_group)"
-                                    style="display: table-cell; font-size: 11px; line-height: 15px">
+                                <a
+                                    @click="goToNvGroup(workload.service_group)"
+                                    style="display: table-cell; font-size: 11px; line-height: 15px; cursor: pointer;"
+                                >
                                     <EOS_LAUNCH_FILLED size="base" color="#3D98D3"></EOS_LAUNCH_FILLED>
                                 </a>
                             </span>


### PR DESCRIPTION
Completed redirection links of impact modal briefs of vulnerabilities page as manager.

ImpactModalWorkloadBrief
<img width="1510" alt="Screenshot 2024-09-12 at 2 12 19 PM" src="https://github.com/user-attachments/assets/91562a4d-c1c2-4a34-839f-6b702925ebc6">

ImpactModalNodeBrief
<img width="1510" alt="Screenshot 2024-09-12 at 2 13 28 PM" src="https://github.com/user-attachments/assets/5543ceaa-749e-4207-8cc1-28d775a70ae3">
