### PR TITLE
#243 There is no display control on auto scan swtich button in the dashboard

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,10 +18,10 @@ defaults:
 
 jobs:
   build-extension-charts:
-    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@9eb70a732e9be146722e1dbab431338366c2afc6 # creators-pkg-v3.0.10
+    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@9bf23dff6650116673346447bcf0b088e0edb27f # creators-pkg-v3.0.12
     permissions:
-      actions: write
       contents: write
+      pull-requests: write
     with:
       target_branch: gh-pages
       tagged_release: ${{ github.ref_name }}

--- a/pkg/neuvector-ui-ext/components/Dashboard/contents/ScoreFactorCommentSlider.vue
+++ b/pkg/neuvector-ui-ext/components/Dashboard/contents/ScoreFactorCommentSlider.vue
@@ -92,4 +92,7 @@ export default {
   color: var(--text-secondary);
   text-align: left;
 }
+.carousel__pagination {
+  top: 100px;
+}
 </style>

--- a/pkg/neuvector-ui-ext/components/Dashboard/contents/VulnerabilitiesInstruction.vue
+++ b/pkg/neuvector-ui-ext/components/Dashboard/contents/VulnerabilitiesInstruction.vue
@@ -4,7 +4,7 @@
   </div>
   <div v-else>
     {{ t('dashboard.heading.guideline.AUTO_SCAN_OFF') }}
-    <div class="toggle-switch mt-10">
+    <div v-if="isAutoScanAuthorized" class="toggle-switch mt-10">
       <ToggleSwitch @update:value="toggleAutoScan" :value="autoScan" :offLabel="'Auto Scan'" />
     </div>
   </div>
@@ -12,16 +12,27 @@
 <script>
 import { ToggleSwitch } from '@components/Form/ToggleSwitch';
 import { updateAutoScan } from '../../../plugins/dashboard-class';
+import { getDisplayFlag } from '../../../utils/auth';
+import { refreshAuth } from '../../../plugins/neuvector-class';
+import { nvVariables } from '../../../types/neuvector';
 
 export default {
-  fetch() {
 
+  async fetch() {
+    let authRes = await refreshAuth();
+    nvVariables.user = authRes.data.token;
+    this.isAutoScanAuthorized = getDisplayFlag('runtime_scan', this.$store);
   },
   props: {
     autoScan: Boolean,
     token: String,
     ns: String,
     currentClusterId: String
+  },
+  data() {
+    return {
+      isAutoScanAuthorized: false
+    };
   },
   components: {
     ToggleSwitch,


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #243 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:
Create a NeuVector read-only user and login to observe the auto scan button. It should not in the dashboard page

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
